### PR TITLE
feat: add manga and volume info data to name templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 changelog-temp.md
 mangal
 
+.DS_Store
+
 ######
 # Go #
 ######

--- a/config/config.go
+++ b/config/config.go
@@ -228,7 +228,7 @@ var Config = config{
 			}),
 			NameTemplateFallback: reg(field[string, string]{
 				Key:         "download.manga.name_template_fallback",
-				Default:     `{{ .Title | sanitize }}`,
+				Default:     `{{ .Manga.Title | sanitize }}`,
 				Description: "Template to use for naming downloaded mangas, when no Anilist data is available.",
 				Validate: func(s string) error {
 					_, err := template.
@@ -247,7 +247,7 @@ var Config = config{
 			}),
 			NameTemplate: reg(field[string, string]{
 				Key:         "download.volume.name_template",
-				Default:     `{{ printf "Vol. %d" .Number | sanitize }}`,
+				Default:     `{{ printf "Vol. %.1f" .Volume.Number | sanitize }}`,
 				Description: "Template to use for naming downloaded volumes.",
 				Validate: func(s string) error {
 					_, err := template.
@@ -261,7 +261,7 @@ var Config = config{
 		Chapter: configDownloadChapter{
 			NameTemplate: reg(field[string, string]{
 				Key:         "download.chapter.name_template",
-				Default:     `{{ printf "[%06.1f] %s" .Number .Title | sanitize }}`,
+				Default:     `{{ printf "[%06.1f] %s" .Chapter.Number .Chapter.Title | sanitize }}`,
 				Description: "Template to use for naming downloaded chapters.",
 				Validate: func(s string) error {
 					_, err := template.

--- a/template/template.go
+++ b/template/template.go
@@ -6,10 +6,27 @@ import (
 
 	"github.com/luevano/libmangal"
 	"github.com/luevano/libmangal/mangadata"
+	"github.com/luevano/libmangal/metadata"
 	"github.com/luevano/mangal/config"
 	"github.com/luevano/mangal/template/funcs"
 	"github.com/luevano/mangal/util"
 )
+
+type mangaTemplateData struct {
+	Manga    mangadata.MangaInfo
+	Metadata *metadata.Metadata
+}
+
+type volumeTemplateData struct {
+	Volume mangadata.VolumeInfo
+	Manga  mangadata.MangaInfo
+}
+
+type chapterTemplateData struct {
+	Chapter mangadata.ChapterInfo
+	Volume  mangadata.VolumeInfo
+	Manga   mangadata.MangaInfo
+}
 
 func Provider(provider libmangal.ProviderInfo) string {
 	var sb strings.Builder
@@ -30,15 +47,20 @@ func Manga(_ string, manga mangadata.Manga) string {
 
 	plt := config.Config.Download.Manga.NameTemplateFallback.Get()
 	// Prioritize the NameTemplate (includes AnilistManga data)
-	metadata := manga.Metadata()
-	if metadata != nil {
+	mangaMetadata := manga.Metadata()
+	if mangaMetadata != nil {
 		plt = config.Config.Download.Manga.NameTemplate.Get()
+	} else {
+		mangaMetadata = &metadata.Metadata{}
 	}
 
 	err := template.Must(template.New("manga").
 		Funcs(funcs.FuncMap).
 		Parse(plt)).
-		Execute(&sb, manga)
+		Execute(&sb, mangaTemplateData{
+			Manga:    manga.Info(),
+			Metadata: mangaMetadata,
+		})
 	if err != nil {
 		util.Errorf("error during execution of the manga name template: %s\n", err)
 	}
@@ -46,13 +68,16 @@ func Manga(_ string, manga mangadata.Manga) string {
 	return sb.String()
 }
 
-func Volume(_ string, manga mangadata.Volume) string {
+func Volume(_ string, volume mangadata.Volume) string {
 	var sb strings.Builder
 
 	err := template.Must(template.New("volume").
 		Funcs(funcs.FuncMap).
 		Parse(config.Config.Download.Volume.NameTemplate.Get())).
-		Execute(&sb, manga.Info())
+		Execute(&sb, volumeTemplateData{
+			Volume: volume.Info(),
+			Manga:  volume.Manga().Info(),
+		})
 	if err != nil {
 		util.Errorf("error during execution of the volume name template: %s\n", err)
 	}
@@ -66,7 +91,11 @@ func Chapter(_ string, chapter mangadata.Chapter) string {
 	err := template.Must(template.New("chapter").
 		Funcs(funcs.FuncMap).
 		Parse(config.Config.Download.Chapter.NameTemplate.Get())).
-		Execute(&sb, chapter.Info())
+		Execute(&sb, chapterTemplateData{
+			Chapter: chapter.Info(),
+			Volume:  chapter.Volume().Info(),
+			Manga:   chapter.Volume().Manga().Info(),
+		})
 	if err != nil {
 		util.Errorf("Error during execution of the chapter name template: %s\n", err)
 	}


### PR DESCRIPTION
PR adds manga info to volume name template & volume and manga info to chapter name template.

I recently switched from original mangal to your fork and noticed that name templates are missing some data that was available in original mangal and that I use in my config.

PS: Thanks for your work on the fork!

